### PR TITLE
feat(layout:navbar): creat navbar, with required elments and conditional rendring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "next-i18next": "^11.2.2",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
+                "react-icons": "^4.11.0",
                 "react-router-dom": "^6.3.0",
                 "react-test-renderer": "^18.2.0"
             },
@@ -11780,6 +11781,14 @@
                 }
             }
         },
+        "node_modules/react-icons": {
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+            "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+            "peerDependencies": {
+                "react": "*"
+            }
+        },
         "node_modules/react-is": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -22971,6 +22980,12 @@
                 "@babel/runtime": "^7.14.5",
                 "html-parse-stringify": "^3.0.1"
             }
+        },
+        "react-icons": {
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+            "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+            "requires": {}
         },
         "react-is": {
             "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "next-i18next": "^11.2.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.11.0",
         "react-router-dom": "^6.3.0",
         "react-test-renderer": "^18.2.0"
     },

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -1,0 +1,100 @@
+import Link from "next/link";
+import React, { useState } from "react";
+import { CgProfile } from "react-icons/cg";
+import { LiaLanguageSolid } from "react-icons/lia";
+
+const Navbar = () => {
+    const [user, setUser] = useState(true); // Set to true if a user is authenticated, otherwise, set it to false
+    const [isProfileDropdownOpen, setProfileDropdownOpen] = useState(false);
+    const [isLanguageDropdownOpen, setLanguageDropdownOpen] = useState(false);
+
+    const toggleProfileDropdown = () => {
+        setProfileDropdownOpen(!isProfileDropdownOpen);
+    };
+
+    const toggleLanguageDropdown = () => {
+        setLanguageDropdownOpen(!isLanguageDropdownOpen);
+    };
+
+    const closeDropdowns = () => {
+        if (isProfileDropdownOpen) setProfileDropdownOpen(false);
+        if (isLanguageDropdownOpen) setLanguageDropdownOpen(false);
+    };
+
+    return (
+        <nav className='w-screen sticky top-0 layout p-4 text-white'>
+            <div className='flex justify-between items-center'>
+                <div>
+                    <Link href='/'>
+                        <div className='text-xl font-bold'>LOGO</div>
+                    </Link>
+                </div>
+                <div className='flex items-center space-x-4'>
+                    <button
+                        className='relative hover:bg-white hover:text-black rounded-full p-2'
+                        onClick={toggleLanguageDropdown}
+                        onBlur={closeDropdowns}
+                    >
+                        <LiaLanguageSolid className='text-2xl' />
+                        {isLanguageDropdownOpen && (
+                            <div className='absolute top-10 right-0 mt-2 layout w-32 p-2'>
+                                <button className='block w-full text-left p-2  hover:bg-amber-300 hover:rounded-lg'>
+                                    English
+                                </button>
+                                <button className='block w-full text-left p-2  hover:bg-amber-300 hover:rounded-lg'>
+                                    العربية
+                                </button>
+                            </div>
+                        )}
+                    </button>
+                    <button
+                        className='relative hover:bg-white hover:text-black rounded-full p-2'
+                        onClick={toggleProfileDropdown}
+                        onBlur={closeDropdowns}
+                    >
+                        <CgProfile className='text-2xl' />
+                        {isProfileDropdownOpen && (
+                            <div className='absolute top-10 right-0 mt-2 layout w-32 p-2'>
+                                {user ? (
+                                    <>
+                                        {/* first case if the profile is clicked and there's a user */}
+                                        <Link href='/' /*"/profile"*/>
+                                            <div className='block w-full text-left p-2  hover:bg-amber-300 hover:rounded-lg'>
+                                                Your Profile
+                                            </div>
+                                        </Link>
+                                        <Link href='/' /*"/events"*/>
+                                            <div className='block w-full text-left p-2  hover:bg-amber-300 hover:rounded-lg'>
+                                                Your Events
+                                            </div>
+                                        </Link>
+                                        <button
+                                            className='block w-full text-left p-2  hover:bg-amber-300 hover:rounded-lg' /*onClick={signOut}*/
+                                        >
+                                            Logout
+                                        </button>
+                                    </>
+                                ) : (
+                                    <>
+                                        <Link href='/' /*"/signin"*/>
+                                            <div className='block w-full text-left p-2  hover:bg-amber-300 hover:rounded-lg'>
+                                                Sign In
+                                            </div>
+                                        </Link>
+                                        <Link href='/' /*"/signup"*/>
+                                            <div className='block w-full text-left p-2  hover:bg-amber-300 hover:rounded-lg'>
+                                                Sign Up
+                                            </div>
+                                        </Link>
+                                    </>
+                                )}
+                            </div>
+                        )}
+                    </button>
+                </div>
+            </div>
+        </nav>
+    );
+};
+
+export default Navbar;

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -1,15 +1,15 @@
 import * as React from "react";
 
+import Navbar from "@/components/navbar/Navbar";
+
 export default function Layout({ children }) {
     // Put Header or Footer around the children element
     // Example
-    // return (
-    //     <>
-    //         <Navbar />
-    //         {children}
-    //         <Footer />
-    //     </>
-    // );
-
-    return <>{children}</>;
+    return (
+        <div className='fit-w-screen'>
+            <Navbar />
+            {children}
+            {/* <Footer /> */}
+        </div>
+    );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+.layout {
+    background: #fda855;
+}


### PR DESCRIPTION
summary:
creat navbar, with logo , language and profile button with temporary redirection to home, and fully functional conditional rendring rendring

more detailes:

- [ ] add tailwind css usage ability across the app

- [ ] navbar background color is FDA855 (according to figma - future chanes will be accepted),  and it's sticky with w-screen

  

1. LOGO 

- [ ] when clicked redirect to home page (on the left side for all devices)

2.  profile(CgProfile from react-icons) conditional rendring button

- [ ] if there is a user, when it's clicked a dropdown menu with you the following option
-your profile 'redirect to the user profile' *=====> temporery to home
-your events 'redirect to an events list page' *=====> temporery to home
-a logout option (keep it as just an option untill firebase authentification ) *=====> temporery to home

- [ ] if there is no user a drop down menu shows up with two options  
-sign in *=====> temporery to home
-sign up *=====> temporery to home

3. Language (LiaLanguageSolid from react-icons) 
- [ ] when clicked a dropdown menu with two option English and العربية

- [ ] onBlur Functionality for the dropdowns

BREAKING CHANGE: we have 70% of the layout

feat #3

@Khalil-NOUI @iman-om  @oualidelh  feel free to review; ask questios, or report fixes